### PR TITLE
re: Enable some off-by-default lints.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ ignored = [
     "metal-lsp",
 ]
 
+[workspace.lints.clippy]
+wildcard_enum_match_arm = "warn"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "warn"
+
 [profile.release]
 lto = "thin"
 strip = true


### PR DESCRIPTION
[`wildcard_enum_match_arm`](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_enum_match_arm)
[`broken_intra_doc_links`](https://doc.rust-lang.org/rustdoc/lints.html#broken_intra_doc_links) - this one actually says that it's warn by default, but it only started working for me after manually enabling it
