### PR TITLE
fix: Add `#[automatically_derived]` to generated `Spanned` impls.

### DIFF
--- a/crates/metal-proc-macros/src/spans/derive.rs
+++ b/crates/metal-proc-macros/src/spans/derive.rs
@@ -25,6 +25,7 @@ fn impl_spanned_for_struct(ident: &Ident, generics: &Generics, data: DataStruct)
     }
 
     quote! {
+        #[automatically_derived]
         impl #generics ::metal_lexer::Spanned for #ident #generics {
             fn span(&self) -> &::metal_lexer::Span {
                 &self.span
@@ -43,6 +44,7 @@ fn impl_spanned_for_enum(ident: &Ident, generics: &Generics, data: DataEnum) -> 
     });
 
     quote! {
+        #[automatically_derived]
         impl #generics ::metal_lexer::Spanned for #ident #generics {
             fn span(&self) -> &::metal_lexer::Span {
                 match self {


### PR DESCRIPTION
See https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute
