### PR TITLE
feat(metal-parser): Implement the parser.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,10 @@ metal-parser = { path = "crates/metal-parser" }
 metal-mir = { path = "crates/metal-mir" }
 metal-proc-macros = { path = "crates/metal-proc-macros" }
 metallic = { path = "crates/metallic" }
+peekable = { path = "crates/peekable" }
 
 [workspace.metadata.cargo-shear]
 ignored = [
-    "metal-ast",
-    "metal-parser",
     "metal-llvm",
     "metallic",
     "metal-formatter",

--- a/crates/metal-ast/src/misc.rs
+++ b/crates/metal-ast/src/misc.rs
@@ -1,4 +1,4 @@
-use metal_lexer::{spanned, Span, Spanned};
+use metal_lexer::{spanned, MaybeSpanned, Span, Spanned};
 
 use crate::Item;
 
@@ -33,4 +33,22 @@ pub enum Mutability {
     Mut(Span),
     /// Immutable.
     Immut,
+}
+
+impl MaybeSpanned for Visibility {
+    fn maybe_span(&self) -> Option<&Span> {
+        match self {
+            Visibility::Pub(span) => Some(span),
+            Visibility::Local => None,
+        }
+    }
+}
+
+impl MaybeSpanned for Mutability {
+    fn maybe_span(&self) -> Option<&Span> {
+        match self {
+            Mutability::Mut(span) => Some(span),
+            Mutability::Immut => None,
+        }
+    }
 }

--- a/crates/metal-lexer/src/lib.rs
+++ b/crates/metal-lexer/src/lib.rs
@@ -11,7 +11,7 @@ use logos::Logos;
 pub use metal_proc_macros::{span, spanned, Spanned};
 
 pub use crate::error::Error;
-pub use crate::span::{Span, Spanned};
+pub use crate::span::{MaybeSpanned, Span, Spanned};
 pub use crate::token::{Token, TokenKind};
 
 pub fn lex(input: &str) -> impl Iterator<Item = Result<Token<'_>, Error>> {

--- a/crates/metal-lexer/src/span.rs
+++ b/crates/metal-lexer/src/span.rs
@@ -25,3 +25,16 @@ impl<T: Spanned> Spanned for Vec<T> {
         span
     }
 }
+
+pub trait MaybeSpanned {
+    fn maybe_span(&self) -> Option<&Span>;
+}
+
+impl<T: Spanned> MaybeSpanned for Option<T> {
+    fn maybe_span(&self) -> Option<&Span> {
+        match self {
+            Some(spanned) => Some(spanned.span()),
+            None => None,
+        }
+    }
+}

--- a/crates/metal-lexer/src/token.rs
+++ b/crates/metal-lexer/src/token.rs
@@ -5,6 +5,7 @@ use crate::error::Error;
 use crate::Span;
 
 /// A lexical unit of Metal code.
+#[derive(Debug)]
 pub struct Token<'src> {
     pub kind: TokenKind<'src>,
     pub span: Span,

--- a/crates/metal-parser/Cargo.toml
+++ b/crates/metal-parser/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 description = "The Metal language parser."
 
 [dependencies]
+peekable = { workspace = true }
+metal-lexer = { workspace = true }
+metal-ast = { workspace = true }

--- a/crates/metal-parser/src/block.rs
+++ b/crates/metal-parser/src/block.rs
@@ -1,0 +1,26 @@
+use metal_ast::{Block, Item};
+use metal_lexer::{span, TokenKind};
+
+use crate::{expect, parse_delimited, parse_item, parser_type, Delimiter};
+
+pub fn parse_block<'src>(parser: parser_type!('src)) -> Block<'src> {
+    let start_span = expect!(parser, TokenKind::OpeningBrace);
+
+    let items = parse_block_raw(parser);
+
+    let end_span = expect!(parser, TokenKind::ClosingBrace);
+
+    Block {
+        items,
+        span: span!(start_span.start..end_span.end),
+    }
+}
+
+pub fn parse_block_raw<'src>(parser: parser_type!('src)) -> Vec<Item<'src>> {
+    parse_delimited(
+        parser,
+        Delimiter::Semicolon,
+        [Delimiter::ClosingBrace],
+        &mut parse_item,
+    )
+}

--- a/crates/metal-parser/src/delimiter.rs
+++ b/crates/metal-parser/src/delimiter.rs
@@ -1,0 +1,25 @@
+use metal_lexer::TokenKind;
+
+pub enum Delimiter {
+    /// Corresponds to [TokenKind::Semicolon](metal_lexer::TokenKind::Semicolon).
+    Semicolon,
+    /// Corresponds to [TokenKind::Comma](metal_lexer::TokenKind::Comma).
+    Comma,
+    /// Corresponds to [TokenKind::ClosingParenthesis](metal_lexer::TokenKind::ClosingParenthesis).
+    ClosingParenthesis,
+    /// Corresponds to [TokenKind::ClosingBrace](metal_lexer::TokenKind::ClosingBrace).
+    ClosingBrace,
+}
+
+impl Delimiter {
+    pub fn same_as(&self, kind: &TokenKind<'_>) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
+        match (self, kind) {
+            (Self::Semicolon, TokenKind::Semicolon) => true,
+            (Self::Comma, TokenKind::Comma) => true,
+            (Self::ClosingParenthesis, TokenKind::ClosingParenthesis) => true,
+            (Self::ClosingBrace, TokenKind::ClosingBrace) => true,
+            _ => false,
+        }
+    }
+}

--- a/crates/metal-parser/src/expr.rs
+++ b/crates/metal-parser/src/expr.rs
@@ -1,0 +1,30 @@
+use metal_ast::Expr;
+use metal_lexer::TokenKind;
+
+use crate::{parse_ident, parse_lit_expr, parser_type};
+
+pub mod lit;
+
+pub fn parse_expr<'src>(parser: parser_type!('src)) -> Expr<'src> {
+    match parser.peek().unwrap().kind {
+        TokenKind::Ident(_) => Expr::Ident(Box::new(parse_ident(parser))),
+        TokenKind::NumLit(_)
+        | TokenKind::BinaryNumLit(_)
+        | TokenKind::HexNumLit(_)
+        | TokenKind::FloatLit(_)
+        | TokenKind::EFloatLit(_)
+        | TokenKind::StrLit(_)
+        | TokenKind::BoolLit(_) => Expr::Lit(Box::new(parse_lit_expr(parser))),
+        _ => panic!("expected an expr, found {:?}", parser.next().unwrap()),
+    }
+}
+
+pub fn parse_expr_specifier<'src>(parser: parser_type!('src)) -> Option<Expr<'src>> {
+    if parser.peek().is_some_and(|t| t.kind.is_assignment()) {
+        parser.next(); // guaranteed to be TokenKind::Assignment
+
+        Some(parse_expr(parser))
+    } else {
+        None
+    }
+}

--- a/crates/metal-parser/src/expr/lit.rs
+++ b/crates/metal-parser/src/expr/lit.rs
@@ -1,0 +1,23 @@
+use metal_ast::{BoolLit, LitExpr, NumLit, StrLit};
+use metal_lexer::{Token, TokenKind};
+
+use crate::parser_type;
+
+pub fn parse_lit_expr<'src>(parser: parser_type!('src)) -> LitExpr<'src> {
+    let Token { kind, span } = parser.next().unwrap();
+
+    match kind {
+        TokenKind::NumLit(v) | TokenKind::HexNumLit(v) | TokenKind::BinaryNumLit(v) => {
+            LitExpr::Num(NumLit {
+                inner: v as f64,
+                span,
+            })
+        }
+        TokenKind::FloatLit(inner) | TokenKind::EFloatLit(inner) => {
+            LitExpr::Num(NumLit { inner, span })
+        }
+        TokenKind::BoolLit(inner) => LitExpr::Bool(BoolLit { inner, span }),
+        TokenKind::StrLit(inner) => LitExpr::Str(StrLit { inner, span }),
+        kind => panic!("expected a literal, found {:?}", Token { kind, span }),
+    }
+}

--- a/crates/metal-parser/src/item.rs
+++ b/crates/metal-parser/src/item.rs
@@ -1,0 +1,40 @@
+use metal_ast::{Item, Visibility};
+use metal_lexer::TokenKind;
+
+use crate::{
+    parse_const_item, parse_enum_item, parse_expr, parse_fn_item, parse_import_item,
+    parse_struct_item, parse_vis, parser_type,
+};
+
+pub mod const_item;
+pub mod enum_item;
+pub mod fn_item;
+pub mod import;
+pub mod struct_item;
+
+pub fn parse_item<'src>(parser: parser_type!('src)) -> Item<'src> {
+    match parser.peek().expect("an item").kind {
+        TokenKind::Const
+        | TokenKind::Enum
+        | TokenKind::Struct
+        | TokenKind::Def
+        | TokenKind::Import
+        | TokenKind::Pub => {
+            let vis = parse_vis(parser);
+
+            parse_item_with_vis(parser, vis)
+        }
+        _ => Item::Expr(parse_expr(parser)),
+    }
+}
+
+pub fn parse_item_with_vis<'src>(parser: parser_type!('src), vis: Visibility) -> Item<'src> {
+    match parser.peek().expect("an item").kind {
+        TokenKind::Const => Item::Const(Box::new(parse_const_item(parser, vis))),
+        TokenKind::Enum => Item::Enum(Box::new(parse_enum_item(parser, vis))),
+        TokenKind::Struct => Item::Struct(Box::new(parse_struct_item(parser, vis))),
+        TokenKind::Def => Item::Fn(Box::new(parse_fn_item(parser, vis))),
+        TokenKind::Import => Item::Import(Box::new(parse_import_item(parser, vis))),
+        _ => panic!("expected an item that's valid with vis quals"),
+    }
+}

--- a/crates/metal-parser/src/item/const_item.rs
+++ b/crates/metal-parser/src/item/const_item.rs
@@ -1,0 +1,23 @@
+use metal_ast::{ConstItem, Visibility};
+use metal_lexer::{span, MaybeSpanned, TokenKind};
+
+use crate::{expect, parse_expr_specifier, parse_ident, parse_ty_qualifier, parser_type};
+
+pub fn parse_const_item<'src>(parser: parser_type!('src), vis: Visibility) -> ConstItem<'src> {
+    let const_span = expect!(parser, TokenKind::Const);
+    let ident = parse_ident(parser);
+    let ty = parse_ty_qualifier(parser);
+    let value = parse_expr_specifier(parser).expect("the constant's value");
+    let end_span = expect!(parser, TokenKind::Semicolon);
+
+    let span_start = vis.maybe_span().unwrap_or(&const_span).start;
+    let span_end = end_span.end;
+
+    ConstItem {
+        vis,
+        ident,
+        ty,
+        value,
+        span: span!(span_start..span_end),
+    }
+}

--- a/crates/metal-parser/src/item/enum_item.rs
+++ b/crates/metal-parser/src/item/enum_item.rs
@@ -1,0 +1,85 @@
+use metal_ast::{EnumBody, EnumBodyItem, EnumItem, EnumVariant, Visibility};
+use metal_lexer::{span, MaybeSpanned, Spanned, TokenKind};
+
+use crate::{expect, parse_fn_item, parse_ident, parse_ty, parse_vis, parser_type};
+
+pub fn parse_enum_item<'src>(parser: parser_type!('src), vis: Visibility) -> EnumItem<'src> {
+    let start_span = expect!(parser, TokenKind::Enum);
+    let ident = parse_ident(parser);
+    let body = parse_enum_body(parser);
+
+    let span_end = body.span().end;
+
+    EnumItem {
+        vis,
+        ident,
+        body,
+        span: span!(start_span.start..span_end),
+    }
+}
+
+pub fn parse_enum_body<'src>(parser: parser_type!('src)) -> EnumBody<'src> {
+    let start_span = expect!(parser, TokenKind::OpeningBrace);
+
+    let mut items = vec![];
+
+    while parser.peek().is_some_and(|t| !t.kind.is_closing_brace()) {
+        items.push(match parser.peek().unwrap().kind {
+            TokenKind::Ident(_) => EnumBodyItem::Variant(parse_enum_variant(parser)),
+            TokenKind::Def | TokenKind::Pub => EnumBodyItem::FnItem({
+                let vis = parse_vis(parser);
+
+                parse_fn_item(parser, vis)
+            }),
+            _ => panic!("expected a enum item, found {:?}", parser.next().unwrap()),
+        });
+    }
+
+    let end_span = expect!(parser, TokenKind::ClosingBrace);
+
+    EnumBody {
+        items,
+        span: span!(start_span.start..end_span.end),
+    }
+}
+
+pub fn parse_enum_variant<'src>(parser: parser_type!('src)) -> EnumVariant<'src> {
+    let ident = parse_ident(parser);
+
+    let (datatype, closing_paren_span) = if parser
+        .peek()
+        .is_some_and(|t| t.kind.is_opening_parenthesis())
+    {
+        parser.next();
+
+        let datatype = if !parser
+            .peek()
+            .is_some_and(|t| t.kind.is_closing_parenthesis())
+        {
+            Some(parse_ty(parser))
+        } else {
+            None
+        };
+
+        let end_span = expect!(parser, TokenKind::ClosingParenthesis);
+
+        (datatype, Some(end_span))
+    } else {
+        (None, None)
+    };
+
+    expect!(parser, TokenKind::Comma);
+
+    let span_start = ident.span().start;
+    let span_end = closing_paren_span
+        .as_ref()
+        .or(datatype.maybe_span())
+        .unwrap_or(ident.span())
+        .end;
+
+    EnumVariant {
+        ident,
+        datatype,
+        span: span!(span_start..span_end),
+    }
+}

--- a/crates/metal-parser/src/item/fn_item.rs
+++ b/crates/metal-parser/src/item/fn_item.rs
@@ -1,0 +1,61 @@
+use metal_ast::{FnInput, FnItem, Visibility};
+use metal_lexer::{span, MaybeSpanned, Spanned, TokenKind};
+
+use crate::{
+    expect, parse_block, parse_delimited, parse_expr_specifier, parse_ident, parse_mutness,
+    parse_ty_qualifier, parser_type, Delimiter,
+};
+
+pub fn parse_fn_item<'src>(parser: parser_type!('src), vis: Visibility) -> FnItem<'src> {
+    let start_span = expect!(parser, TokenKind::Def);
+
+    let ident = parse_ident(parser);
+
+    expect!(parser, TokenKind::OpeningParenthesis);
+
+    let inputs = parse_delimited(
+        parser,
+        Delimiter::Comma,
+        [Delimiter::ClosingParenthesis],
+        &mut parse_fn_input,
+    );
+
+    expect!(parser, TokenKind::ClosingParenthesis);
+
+    let return_type = parse_ty_qualifier(parser);
+
+    let body = parse_block(parser);
+
+    let span_end = body.span.end;
+
+    FnItem {
+        vis,
+        ident,
+        inputs,
+        return_type,
+        body,
+        span: span!(start_span.start..span_end),
+    }
+}
+
+pub fn parse_fn_input<'src>(parser: parser_type!('src)) -> FnInput<'src> {
+    let mutness = parse_mutness(parser);
+    let ident = parse_ident(parser);
+    let ty = parse_ty_qualifier(parser); // `self` can omit the type
+    let default = parse_expr_specifier(parser);
+
+    let span_start = mutness.maybe_span().unwrap_or(&ident.span).start;
+    let span_end = default
+        .maybe_span()
+        .or(ty.maybe_span())
+        .unwrap_or(ident.span())
+        .end;
+
+    FnInput {
+        mutness,
+        ident,
+        ty,
+        default: None,
+        span: span!(span_start..span_end),
+    }
+}

--- a/crates/metal-parser/src/item/import.rs
+++ b/crates/metal-parser/src/item/import.rs
@@ -1,0 +1,66 @@
+use metal_ast::{ImportItem, ImportTree, MultiImport, SegmentImport, Visibility};
+use metal_lexer::{span, MaybeSpanned, Spanned, TokenKind};
+
+use crate::{expect, parse_delimited, parse_ident, parser_type, Delimiter};
+
+pub fn parse_import_item<'src>(parser: parser_type!('src), vis: Visibility) -> ImportItem<'src> {
+    let import_span = expect!(parser, TokenKind::Import);
+    let tree = parse_import_tree(parser);
+    let end_span = expect!(parser, TokenKind::Semicolon);
+
+    let span_start = vis.maybe_span().unwrap_or(&import_span).start;
+    let span_end = end_span.end;
+
+    ImportItem {
+        vis,
+        tree,
+        span: span!(span_start..span_end),
+    }
+}
+
+pub fn parse_import_tree<'src>(parser: parser_type!('src)) -> ImportTree<'src> {
+    match parser.peek().unwrap().kind {
+        TokenKind::Ident(_) => parse_name_or_segment_import_tree(parser),
+        TokenKind::OpeningBrace => ImportTree::Multiple(Box::new(parse_multi_import(parser))),
+        _ => panic!("expected an import tree, found {:?}", parser.next()),
+    }
+}
+
+pub fn parse_name_or_segment_import_tree<'src>(parser: parser_type!('src)) -> ImportTree<'src> {
+    let segment = parse_ident(parser);
+
+    if parser.peek().is_some_and(|t| t.kind.is_period()) {
+        parser.next(); // guaranteed to be a TokenKind::Period
+
+        let rest = parse_import_tree(parser);
+
+        let span_start = segment.span().start;
+        let span_end = rest.span().end;
+
+        ImportTree::Segment(Box::new(SegmentImport {
+            segment,
+            rest,
+            span: span!(span_start..span_end),
+        }))
+    } else {
+        ImportTree::Name(Box::new(segment))
+    }
+}
+
+pub fn parse_multi_import<'src>(parser: parser_type!('src)) -> MultiImport<'src> {
+    let start_span = expect!(parser, TokenKind::OpeningBrace);
+
+    let subtrees = parse_delimited(
+        parser,
+        Delimiter::Comma,
+        [Delimiter::ClosingBrace],
+        &mut parse_import_tree,
+    );
+
+    let end_span = expect!(parser, TokenKind::ClosingBrace);
+
+    MultiImport {
+        subtrees,
+        span: span!(start_span.start..end_span.end),
+    }
+}

--- a/crates/metal-parser/src/item/struct_item.rs
+++ b/crates/metal-parser/src/item/struct_item.rs
@@ -1,0 +1,59 @@
+use metal_ast::{StructBody, StructBodyItem, StructField, StructItem, Visibility};
+use metal_lexer::{span, MaybeSpanned, Spanned, TokenKind};
+
+use crate::{expect, parse_fn_item, parse_ident, parse_ty_qualifier, parse_vis, parser_type};
+
+pub fn parse_struct_item<'src>(parser: parser_type!('src), vis: Visibility) -> StructItem<'src> {
+    let start_span = expect!(parser, TokenKind::Struct);
+    let ident = parse_ident(parser);
+    let body = parse_struct_body(parser);
+
+    let span_end = body.span().end;
+
+    StructItem {
+        vis,
+        ident,
+        body,
+        span: span!(start_span.start..span_end),
+    }
+}
+
+pub fn parse_struct_body<'src>(parser: parser_type!('src)) -> StructBody<'src> {
+    let start_span = expect!(parser, TokenKind::OpeningBrace);
+
+    let mut items = vec![];
+
+    while parser.peek().is_some_and(|t| !t.kind.is_closing_brace()) {
+        let vis = parse_vis(parser);
+
+        items.push(match parser.peek().unwrap().kind {
+            TokenKind::Ident(_) => StructBodyItem::Field(parse_struct_field(parser, vis)),
+            TokenKind::Def => StructBodyItem::FnItem(parse_fn_item(parser, vis)),
+            _ => panic!("expected a struct item, found {:?}", parser.next().unwrap()),
+        });
+    }
+
+    let end_span = expect!(parser, TokenKind::ClosingBrace);
+
+    StructBody {
+        items,
+        span: span!(start_span.start..end_span.end),
+    }
+}
+
+pub fn parse_struct_field<'src>(parser: parser_type!('src), vis: Visibility) -> StructField<'src> {
+    let ident = parse_ident(parser);
+    let ty = parse_ty_qualifier(parser).expect("expected a type qualifier");
+
+    expect!(parser, TokenKind::Comma);
+
+    let span_start = vis.maybe_span().unwrap_or(ident.span()).start;
+    let span_end = ty.span().end;
+
+    StructField {
+        vis,
+        ident,
+        ty,
+        span: span!(span_start..span_end),
+    }
+}

--- a/crates/metal-parser/src/lib.rs
+++ b/crates/metal-parser/src/lib.rs
@@ -1,14 +1,29 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+#![feature(decl_macro, stmt_expr_attributes, new_range_api)]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+mod block;
+mod delimiter;
+mod expr;
+mod item;
+mod misc;
+mod ty;
+mod utils;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use crate::{
+    block::{parse_block, parse_block_raw},
+    delimiter::Delimiter,
+    expr::{lit::parse_lit_expr, parse_expr, parse_expr_specifier},
+    item::{
+        const_item::parse_const_item,
+        enum_item::{parse_enum_body, parse_enum_item, parse_enum_variant},
+        fn_item::{parse_fn_input, parse_fn_item},
+        import::{
+            parse_import_item, parse_import_tree, parse_multi_import,
+            parse_name_or_segment_import_tree,
+        },
+        parse_item,
+        struct_item::{parse_struct_body, parse_struct_field, parse_struct_item},
+    },
+    misc::{parse_ident, parse_mutness, parse_vis},
+    ty::{parse_ty, parse_ty_qualifier},
+    utils::{expect, parse_delimited, parser_type},
+};

--- a/crates/metal-parser/src/misc.rs
+++ b/crates/metal-parser/src/misc.rs
@@ -1,0 +1,26 @@
+use metal_ast::{Ident, Mutability, Visibility};
+use metal_lexer::TokenKind;
+
+use crate::{expect, parser_type};
+
+pub fn parse_ident<'src>(parser: parser_type!('src)) -> Ident<'src> {
+    let (inner, span) = expect!(parser, TokenKind::Ident(inner), inner);
+
+    Ident { inner, span }
+}
+
+pub fn parse_mutness<'src>(parser: parser_type!('src)) -> Mutability {
+    if parser.peek().is_some_and(|t| t.kind.is_mut()) {
+        Mutability::Mut(parser.next().unwrap().span)
+    } else {
+        Mutability::Immut
+    }
+}
+
+pub fn parse_vis<'src>(parser: parser_type!('src)) -> Visibility {
+    if parser.peek().is_some_and(|t| t.kind.is_pub()) {
+        Visibility::Pub(parser.next().unwrap().span)
+    } else {
+        Visibility::Local
+    }
+}

--- a/crates/metal-parser/src/ty.rs
+++ b/crates/metal-parser/src/ty.rs
@@ -1,0 +1,17 @@
+use metal_ast::Ty;
+
+use crate::{parse_ident, parser_type};
+
+pub fn parse_ty<'src>(parser: parser_type!('src)) -> Ty<'src> {
+    Ty::Ident(Box::new(parse_ident(parser)))
+}
+
+pub fn parse_ty_qualifier<'src>(parser: parser_type!('src)) -> Option<Ty<'src>> {
+    if parser.peek().is_some_and(|t| t.kind.is_colon()) {
+        parser.next();
+
+        Some(parse_ty(parser))
+    } else {
+        None
+    }
+}

--- a/crates/metal-parser/src/utils.rs
+++ b/crates/metal-parser/src/utils.rs
@@ -1,0 +1,55 @@
+use metal_lexer::Token;
+use peekable::Peekable;
+
+use crate::Delimiter;
+
+pub macro parser_type($lt:lifetime) {
+    &mut impl ::peekable::Peekable<Item = ::metal_lexer::Token<$lt>>
+}
+
+/// Asserts that the next token is of the given variant, and returns a tuple
+/// of `(<return expr>, metal_lexer::Span)`. If the return expression is empty, only
+/// the span is return
+pub macro expect {
+    ($iter:expr, $variant:pat) => {{
+        let (_, span) = $crate::utils::expect!($iter, $variant, ());
+        span
+    }},
+    ($iter:expr, $variant:pat, $ret:expr) => {
+        match $iter.next() {
+            Some(::metal_lexer::Token { kind: $variant, span }) => ($ret, span),
+            other => panic!("expected {}, found {other:?}", stringify!($variant)),
+        }
+    }
+}
+
+// TODO: Should we make this return an iterator? Should be fine with a `#[must_use]`
+/// Parses a list of values (as defined by the passed callback) separated by the specified delimiter.
+/// ``stop_at`` is used to know when to stop looking for new values.
+pub fn parse_delimited<
+    'src,
+    V,
+    Parser: Peekable<Item = Token<'src>>,
+    ParserFn: FnMut(&mut Parser) -> V,
+    const N: usize,
+>(
+    parser: &mut Parser,
+    delimiter: Delimiter,
+    stop_at: [Delimiter; N], // TODO: see if making this a callback improves perf
+    callback: &mut ParserFn,
+) -> Vec<V> {
+    let mut values = vec![];
+
+    while parser
+        .peek()
+        .is_some_and(|t| !(stop_at.iter().any(|k| k.same_as(&t.kind))))
+    {
+        values.push(callback(parser));
+
+        if parser.peek().is_some_and(|t| delimiter.same_as(&t.kind)) {
+            parser.next();
+        }
+    }
+
+    values
+}

--- a/crates/metal/Cargo.toml
+++ b/crates/metal/Cargo.toml
@@ -7,6 +7,8 @@ description = "The Metal CLI."
 [dependencies]
 tapcli = { workspace = true }
 thiserror = { workspace = true }
+metal-lexer = { workspace = true }
+metal-parser = { workspace = true }
 
 [features]
 default = []

--- a/crates/metal/src/cli/dev.rs
+++ b/crates/metal/src/cli/dev.rs
@@ -1,10 +1,12 @@
+use parse::DevParseCommand;
+
 use crate::error::Error;
 
+mod parse;
+
 pub enum DevCommand {
-    /// A placeholder command that should be removed once at least one
-    /// other subcommand is added (i.e. this command's only purpose is
-    /// to make instantiating DevCommand possible).
-    Placeholder,
+    /// Parse a Metal source file and debug-print it's AST.
+    Parse(DevParseCommand),
 }
 
 impl tapcli::Command for DevCommand {
@@ -14,19 +16,14 @@ impl tapcli::Command for DevCommand {
         let arg = parser.next().ok_or(Error::InsufficientArguments)?;
 
         match arg.as_ref() {
-            tapcli::ArgRef::Value("placeholder") => Ok(Self::Placeholder),
+            tapcli::ArgRef::Value("parse") => Ok(Self::Parse(DevParseCommand::parse(parser)?)),
             _ => Err(Error::UnrecognizedArgument(arg)),
         }
     }
 
     fn run(self) -> Result<Self::Output, Self::Error> {
         match self {
-            DevCommand::Placeholder => {
-                eprintln!("I am a gorgeous placeholder. Normally, one would instead do ::Placeholder(cmd) => cmd.run()
-                but gorgeous placeholders are an exception, because i said so and because i am lazy. Also it's getting late.");
-
-                Ok(())
-            }
+            DevCommand::Parse(cmd) => cmd.run(),
         }
     }
 }

--- a/crates/metal/src/cli/dev/parse.rs
+++ b/crates/metal/src/cli/dev/parse.rs
@@ -1,0 +1,31 @@
+use crate::error::Error;
+
+pub struct DevParseCommand {
+    path: String,
+}
+
+impl tapcli::Command for DevParseCommand {
+    type Error = Error;
+
+    fn parse(parser: &mut tapcli::Parser) -> Result<Self, Self::Error> {
+        let Some(tapcli::Arg::Value(path)) = parser.next() else {
+            panic!("file path");
+        };
+
+        Ok(Self { path })
+    }
+
+    fn run(self) -> Result<Self::Output, Self::Error> {
+        let contents = std::fs::read_to_string(self.path).unwrap();
+
+        let mut tokens = metal_lexer::lex(&contents)
+            .filter_map(Result::ok)
+            .peekable();
+
+        let ast = metal_parser::parse_block_raw(&mut tokens);
+
+        eprintln!("{:#?}", ast);
+
+        Ok(())
+    }
+}

--- a/crates/peekable/Cargo.toml
+++ b/crates/peekable/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "peekable"
+version = "0.1.0"
+edition = "2021"
+description = "`std::iter::Peekable` as a trait."

--- a/crates/peekable/src/lib.rs
+++ b/crates/peekable/src/lib.rs
@@ -1,0 +1,15 @@
+/// Trait version of [std::iter::Peekable].
+pub trait Peekable: Iterator {
+    fn peek(&mut self) -> Option<&Self::Item>;
+    fn peek_mut(&mut self) -> Option<&mut Self::Item>;
+}
+
+impl<I: Iterator> Peekable for std::iter::Peekable<I> {
+    fn peek(&mut self) -> Option<&Self::Item> {
+        self.peek()
+    }
+
+    fn peek_mut(&mut self) -> Option<&mut Self::Item> {
+        self.peek_mut()
+    }
+}


### PR DESCRIPTION
TODO:
- ~~replace `&dyn` with `&impl` per [this RLO thread](https://users.rust-lang.org/t/should-i-prefer-impl-impl-mut-impl-or-box-dyn-dyn-mut-dyn-by-default/41778/9)~~ impossible because of limitations around `impl Trait`