### PR TITLE
feat(metal-proc-macros): Reimplement `metal_lexer::span` as a proc-macro.

### DIFF
--- a/crates/metal-lexer/src/lib.rs
+++ b/crates/metal-lexer/src/lib.rs
@@ -8,10 +8,10 @@ mod tests;
 mod token;
 
 use logos::Logos;
-pub use metal_proc_macros::{spanned, Spanned};
+pub use metal_proc_macros::{span, spanned, Spanned};
 
 pub use crate::error::Error;
-pub use crate::span::{span, Span, Spanned};
+pub use crate::span::{Span, Spanned};
 pub use crate::token::{Token, TokenKind};
 
 pub fn lex(input: &str) -> impl Iterator<Item = Result<Token<'_>, Error>> {

--- a/crates/metal-lexer/src/span.rs
+++ b/crates/metal-lexer/src/span.rs
@@ -1,3 +1,5 @@
+use crate::span;
+
 /// A span in a source file.
 pub type Span = core::range::Range<usize>;
 
@@ -21,18 +23,5 @@ impl<T: Spanned> Spanned for Vec<T> {
         let span = Box::leak(span_box);
 
         span
-    }
-}
-
-/// Create a `core::range::Range` using the usual range syntax.
-pub macro span {
-    ($start:ident..$end:expr) => {
-        $crate::span!(@priv $start, $end)
-    },
-    ($start:literal..$end:expr) => {
-        $crate::span!(@priv $start, $end)
-    },
-    (@priv $start:expr, $end:expr) => {
-        ::core::range::Range { start: $start, end: $end }
     }
 }

--- a/crates/metal-proc-macros/src/lib.rs
+++ b/crates/metal-proc-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(extend_one, let_chains, proc_macro_quote)]
+
 use proc_macro::TokenStream;
 use proc_macro_error2::ResultExt;
 use syn::parse_macro_input;
@@ -15,4 +17,10 @@ pub fn spanned(_: TokenStream, item: TokenStream) -> TokenStream {
     crate::spans::attribute::spanned_impl(item.into())
         .unwrap_or_abort()
         .into()
+}
+
+/// Create a `core::range::Range` using the familiar range syntax.
+#[proc_macro]
+pub fn span(input: TokenStream) -> TokenStream {
+    crate::spans::instance::span_impl(input)
 }

--- a/crates/metal-proc-macros/src/spans/instance.rs
+++ b/crates/metal-proc-macros/src/spans/instance.rs
@@ -1,0 +1,39 @@
+use proc_macro::{quote, Spacing, TokenStream, TokenTree};
+
+pub fn span_impl(input: TokenStream) -> TokenStream {
+    let mut input = input.into_iter();
+    let mut span_start = TokenStream::new();
+
+    while let Some(tt) = input.next() {
+        // the ".." syntax in terms of TokenTrees is represented as two
+        // TokenTree::Punct tokens with .char == '.', with the first dot
+        // having .spacing == Joint (see Spacing's docs for what that means)
+        // and the latter having .spacing == Alone. below, we check exactly
+        // for that
+
+        if is_dot(Some(&tt), Spacing::Joint) {
+            assert!(is_dot(input.next().as_ref(), Spacing::Alone));
+
+            break;
+        } else {
+            span_start.extend_one(tt);
+        }
+    }
+
+    let span_end = TokenStream::from_iter(input);
+
+    quote! {
+        ::core::range::Range { start: $span_start, end: $span_end }
+    }
+}
+
+fn is_dot(tt: Option<&TokenTree>, spacing: Spacing) -> bool {
+    if let Some(TokenTree::Punct(p)) = tt
+        && p.as_char() == '.'
+        && p.spacing() == spacing
+    {
+        return true;
+    }
+
+    false
+}

--- a/crates/metal-proc-macros/src/spans/mod.rs
+++ b/crates/metal-proc-macros/src/spans/mod.rs
@@ -1,2 +1,3 @@
 pub mod attribute;
 pub mod derive;
+pub mod instance;


### PR DESCRIPTION
The upside is that now it's possible to use arbitrary expressions in place of `start` and `end`, which was impossible to do
with regular macros because of compiler's limited ability to match fragment specifiers. This comes up in literally every
function of the parser.

The not-upside-nor-downside is that rust-analyzer is still able to handle completions inside the macro pretty well.

Te downside is, like with any proc-macro, performance, which is why this PR is currently a draft. It's not *terrible* terrible,
but it's (expectedly) much worse than the "old" `span!` was. I have a few ideas to fix this, however, stay tuned.
