### PR TITLE
fix!: Remove `impl Spanned for Vec<T: Spanned>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ ignored = [
     "metal-lsp",
 ]
 
+
 [workspace.lints.clippy]
 wildcard_enum_match_arm = "warn"
 


### PR DESCRIPTION
fix: Remove `impl Spanned for Vec<T: Spanned>`

fix: Remove `impl Spanned for Vec<T: Spanned>`