### PR TITLE
fix(metal-proc-macros): Add `#[proc_macro_error]` to `derive_spanned` and `spanned`.

### DIFF
--- a/crates/metal-proc-macros/src/lib.rs
+++ b/crates/metal-proc-macros/src/lib.rs
@@ -1,17 +1,19 @@
 #![feature(extend_one, let_chains, proc_macro_quote)]
 
 use proc_macro::TokenStream;
-use proc_macro_error2::ResultExt;
+use proc_macro_error2::{proc_macro_error, ResultExt};
 use syn::parse_macro_input;
 
 mod spans;
 
+#[proc_macro_error]
 #[proc_macro_derive(Spanned)]
 pub fn derive_spanned(input: TokenStream) -> TokenStream {
     crate::spans::derive::derive_spanned_impl(parse_macro_input!(input as syn::DeriveInput)).into()
 }
 
 /// Add a `span: metal_lexer::Span` field to a named struct.
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn spanned(_: TokenStream, item: TokenStream) -> TokenStream {
     crate::spans::attribute::spanned_impl(item.into())


### PR DESCRIPTION
Due to an oversight, proc-macro-error2 failed to provide meaningful errors for macro invocations. This fixes that.
