### PR TITLE
feat(metal-lexer): Derive `EnumAsInner` for `TokenKind`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ quote = "1.0.37"
 proc-macro2 = "1.0.89"
 proc-macro-error2 = "2.0.1"
 llvm-sys = { version = "180" }
+enum-as-inner = "0.6.1"
 
 metal = { path = "crates/metal" }
 metal-ast = { path = "crates/metal-ast" }

--- a/crates/metal-lexer/Cargo.toml
+++ b/crates/metal-lexer/Cargo.toml
@@ -8,3 +8,4 @@ description = "The Metal language lexer and proc-macro definitions."
 metal-proc-macros = { workspace = true }
 logos = { workspace = true }
 thiserror = { workspace = true }
+enum-as-inner = { workspace = true }

--- a/crates/metal-lexer/src/token.rs
+++ b/crates/metal-lexer/src/token.rs
@@ -13,7 +13,7 @@ pub struct Token<'src> {
 // FIXME: Switch to a manual implementation. logos, even with our fixes, is not fully sound.
 
 #[rustfmt::skip]
-#[derive(Logos, Debug, PartialEq)]
+#[derive(Logos, Debug, PartialEq, enum_as_inner::EnumAsInner)]
 #[logos(error = Error)]
 #[logos(skip " \t\r\n")]
 #[logos(subpattern int = r"[0-9](_?[0-9])*_?")]


### PR DESCRIPTION
This PR adds `is_`, `as_`, `as_mut_`, and `into` methods for every variant of the `TokenKind` enum. If you're thinking
"wouldn't that be, like, a bajillion of methods", you're correct. Exactly because of that, i measured the from-scratch
build time impact of using the `enum_as_inner` directly versus implementing only the part we need (`is_` fns), and,
surprisingly, it didn't matter all that much. Given that, i decided to use the crate instead of going with a custom
implementation.

Below are the benchmarks and the manual implementation source.

```
// before any change
metal on main [!] via Rust took 1m15s
> hyperfine --prepare "cargo clean" "cargo build"
Benchmark 1: cargo build
  Time (mean ± σ):      7.050 s ±  0.144 s    [User: 22.096 s, System: 5.803 s]
  Range (min … max):    6.875 s …  7.363 s    10 runs

// enum-as-inner
metal on main [!] via Rust took 7s
> hyperfine --prepare "cargo clean" "cargo build"
Benchmark 1: cargo build
  Time (mean ± σ):      7.221 s ±  0.065 s    [User: 22.786 s, System: 6.114 s]
  Range (min … max):    7.091 s …  7.322 s    10 runs

// metal-proc-macros
metal on main [!?] via Rust 
> hyperfine --prepare "cargo clean" "cargo build"
Benchmark 1: cargo build
  Time (mean ± σ):      7.183 s ±  0.058 s    [User: 22.190 s, System: 5.896 s]
  Range (min … max):    7.090 s …  7.304 s    10 runs
```

<details>
    <summary>Manual implementation source</summary>

```rs
#[proc_macro_error]
#[proc_macro_derive(IsVariant)]
pub fn derive_is_variant(input: TokenStream) -> TokenStream {
    crate::is_variant::impl_derive_is_variant(input.into())
        .unwrap_or_abort()
        .into()
}

// ...

use proc_macro2::{Ident, Span, TokenStream};
use proc_macro_error2::{abort, Diagnostic};
use quote::quote;
use syn::ItemEnum;

pub fn impl_derive_is_variant(input: TokenStream) -> Result<TokenStream, Diagnostic> {
    let enum_: ItemEnum = syn::parse2(input)?;

    let name = &enum_.ident;
    let (impl_generics, type_generics, where_clause) = enum_.generics.split_for_impl();

    let fns = enum_.variants.into_iter().map(|v| {
        let variant_name = &v.ident;

        let fn_name = Ident::new(
            &format!("is_{}", variant_name).to_ascii_lowercase(),
            Span::call_site(),
        );

        let pattern = match &v.fields {
            syn::Fields::Unit => quote! {},
            syn::Fields::Unnamed(_) => {
                let pats = (0..v.fields.len()).map(|i| {
                    let pat_name = Ident::new(&format!("match_{}", i), Span::call_site());

                    quote! { #pat_name, }
                });

                quote! { ( #(#pats)* ) }
            }
            other => abort!(
                other,
                "enum variants with struct-like data are not supported"
            ),
        };

        quote! {
            pub fn #fn_name (&self) -> bool {
                matches!(self, Self :: #variant_name #pattern )
            }
        }
    });

    Ok(quote! {
        impl #impl_generics #name #type_generics #where_clause {
            #(#fns)*
        }
    })
}
```

</details>
