### PR TITLE
refactor!: codegen_* -> llvm_

### DIFF
--- a/crates/metal-codegen-llvm/src/expr.rs
+++ b/crates/metal-codegen-llvm/src/expr.rs
@@ -24,14 +24,14 @@ fn args_to_values(llvm: &mut crate::LLVMRefs, module: &Module, args: &[Expr]) ->
     let mut v = Vec::with_capacity(args.len());
 
     for arg in args {
-        v.push(arg.codegen_value(llvm, module));
+        v.push(arg.llvm_value(llvm, module));
     }
 
     v
 }
 
 impl CodeGenValue for Expr {
-    fn codegen_value(
+    fn llvm_value(
         &self,
         llvm: &mut crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
@@ -47,7 +47,7 @@ impl CodeGenValue for Expr {
                 let args_num = fcall.arguments.len();
                 LLVMBuildCall2(
                     llvm.builder,
-                    fcall.signature.return_type.codegen_type(llvm, module),
+                    fcall.signature.return_type.llvm_type(llvm, module),
                     func,
                     args_to_values(llvm, module, &fcall.arguments).as_mut_ptr(),
                     args_num as c_uint,
@@ -57,9 +57,9 @@ impl CodeGenValue for Expr {
             Self::Literal(lit) => match lit.as_ref() {
                 Literal::Boolean(b) => unsafe {
                     if b.value {
-                        LLVMConstInt(Primitive::I8.codegen_type(llvm, module), 1, 0)
+                        LLVMConstInt(Primitive::I8.llvm_type(llvm, module), 1, 0)
                     } else {
-                        LLVMConstInt(Primitive::I8.codegen_type(llvm, module), 0, 0)
+                        LLVMConstInt(Primitive::I8.llvm_type(llvm, module), 0, 0)
                     }
                 },
                 Literal::Number(n) => unsafe {
@@ -69,7 +69,7 @@ impl CodeGenValue for Expr {
                         (0, n.value as u64)
                     };
 
-                    LLVMConstInt(n.primitive.codegen_type(llvm, module), value, sign_extend)
+                    LLVMConstInt(n.primitive.llvm_type(llvm, module), value, sign_extend)
                 },
                 Literal::String(s) => unsafe {
                     let s_len = s.value.len();
@@ -80,7 +80,7 @@ impl CodeGenValue for Expr {
             Self::Assignment(a) => unsafe {
                 LLVMBuildStore(
                     llvm.builder,
-                    a.expr.as_ref().unwrap().codegen_value(llvm, module),
+                    a.expr.as_ref().unwrap().llvm_value(llvm, module),
                     *llvm.locals.get(a.name).unwrap(),
                 )
             },
@@ -89,7 +89,7 @@ impl CodeGenValue for Expr {
 
                 LLVMBuildLoad2(
                     llvm.builder,
-                    l.ty.codegen_type(llvm, module),
+                    l.ty.llvm_type(llvm, module),
                     *llvm.locals.get(l.name).unwrap(),
                     c_name.as_ptr(),
                 )
@@ -100,15 +100,15 @@ impl CodeGenValue for Expr {
                 if m.float {
                     return LLVMBuildFAdd(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 LLVMBuildAdd(
                     llvm.builder,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },
@@ -117,15 +117,15 @@ impl CodeGenValue for Expr {
                 if m.float {
                     return LLVMBuildFSub(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 LLVMBuildSub(
                     llvm.builder,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },
@@ -134,23 +134,23 @@ impl CodeGenValue for Expr {
                 if m.float {
                     return LLVMBuildFDiv(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 if m.signed {
                     return LLVMBuildSDiv(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 LLVMBuildUDiv(
                     llvm.builder,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },
@@ -159,15 +159,15 @@ impl CodeGenValue for Expr {
                 if m.float {
                     return LLVMBuildFMul(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 LLVMBuildMul(
                     llvm.builder,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },
@@ -176,23 +176,23 @@ impl CodeGenValue for Expr {
                 if m.float {
                     LLVMBuildFRem(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 if m.signed {
                     return LLVMBuildSRem(
                         llvm.builder,
-                        m.a.codegen_value(llvm, module),
-                        m.b.codegen_value(llvm, module),
+                        m.a.llvm_value(llvm, module),
+                        m.b.llvm_value(llvm, module),
                         name.as_ptr(),
                     );
                 }
                 LLVMBuildURem(
                     llvm.builder,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },
@@ -201,8 +201,8 @@ impl CodeGenValue for Expr {
                 LLVMBuildFCmp(
                     llvm.builder,
                     LLVMRealPredicate::LLVMRealOGT,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },
@@ -211,8 +211,8 @@ impl CodeGenValue for Expr {
                 LLVMBuildFCmp(
                     llvm.builder,
                     LLVMRealPredicate::LLVMRealOLT,
-                    m.a.codegen_value(llvm, module),
-                    m.b.codegen_value(llvm, module),
+                    m.a.llvm_value(llvm, module),
+                    m.b.llvm_value(llvm, module),
                     name.as_ptr(),
                 )
             },

--- a/crates/metal-codegen-llvm/src/lib.rs
+++ b/crates/metal-codegen-llvm/src/lib.rs
@@ -27,11 +27,11 @@ pub struct LLVMRefs {
 }
 
 pub trait CodeGenValue {
-    fn codegen_value(&self, llvm: &mut LLVMRefs, module: &Module) -> LLVMValueRef;
+    fn llvm_value(&self, llvm: &mut LLVMRefs, module: &Module) -> LLVMValueRef;
 }
 
 pub trait CodeGenType {
-    fn codegen_type(&self, llvm: &LLVMRefs, module: &Module) -> LLVMTypeRef;
+    fn llvm_type(&self, llvm: &LLVMRefs, module: &Module) -> LLVMTypeRef;
 }
 
 pub fn get_types<'a>(
@@ -42,7 +42,7 @@ pub fn get_types<'a>(
 ) -> Vec<LLVMTypeRef> {
     let mut v = Vec::with_capacity(*cap);
     for t in types {
-        v.push(t.codegen_type(llvm, module))
+        v.push(t.llvm_type(llvm, module))
     }
     v
 }

--- a/crates/metal-codegen-llvm/src/primitives.rs
+++ b/crates/metal-codegen-llvm/src/primitives.rs
@@ -9,7 +9,7 @@ use metal_mir::types::primitives::Primitive;
 use crate::CodeGenType;
 
 impl CodeGenType for Primitive {
-    fn codegen_type(
+    fn llvm_type(
         &self,
         llvm: &crate::LLVMRefs,
         _module: &metal_mir::parcel::Module,

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -13,30 +13,30 @@ pub mod constant;
 pub mod function_definition;
 
 impl CodeGenValue for Statement {
-    fn codegen_value(
+    fn llvm_value(
         &self,
         llvm: &mut crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
     ) -> LLVMValueRef {
         match self {
-            Self::FunctionDefine(def) => def.codegen_value(llvm, module),
-            Self::Constant(c) => c.codegen_value(llvm, module),
+            Self::FunctionDefine(def) => def.llvm_value(llvm, module),
+            Self::Constant(c) => c.llvm_value(llvm, module),
             Self::Let(l) => unsafe {
                 let c_name = CString::new(l.name).unwrap();
                 let a = LLVMBuildAlloca(
                     llvm.builder,
-                    l.ty.codegen_type(llvm, module),
+                    l.ty.llvm_type(llvm, module),
                     c_name.as_ptr(),
                 );
                 if let Some(e) = &l.expr {
-                    LLVMBuildStore(llvm.builder, e.codegen_value(llvm, module), a);
+                    LLVMBuildStore(llvm.builder, e.llvm_value(llvm, module), a);
                 }
                 llvm.locals.insert(l.name, a);
                 a
             },
             Self::Extern(e) => unsafe {
                 let c_name = CString::new(e.name.as_str()).unwrap();
-                LLVMAddFunction(llvm.module, c_name.as_ptr(), e.codegen_type(llvm, module))
+                LLVMAddFunction(llvm.module, c_name.as_ptr(), e.llvm_type(llvm, module))
             },
         }
     }

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -23,11 +23,8 @@ impl CodeGenValue for Statement {
             Self::Constant(c) => c.llvm_value(llvm, module),
             Self::Let(l) => unsafe {
                 let c_name = CString::new(l.name).unwrap();
-                let a = LLVMBuildAlloca(
-                    llvm.builder,
-                    l.ty.llvm_type(llvm, module),
-                    c_name.as_ptr(),
-                );
+                let a =
+                    LLVMBuildAlloca(llvm.builder, l.ty.llvm_type(llvm, module), c_name.as_ptr());
                 if let Some(e) = &l.expr {
                     LLVMBuildStore(llvm.builder, e.llvm_value(llvm, module), a);
                 }

--- a/crates/metal-codegen-llvm/src/stmt/constant.rs
+++ b/crates/metal-codegen-llvm/src/stmt/constant.rs
@@ -12,7 +12,7 @@ use super::{CodeGenType, CodeGenValue};
 use crate::get_linkage_from_vis;
 
 impl CodeGenValue for Constant {
-    fn codegen_value(
+    fn llvm_value(
         &self,
         llvm: &mut crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
@@ -22,13 +22,13 @@ impl CodeGenValue for Constant {
         unsafe {
             let global_var = LLVMAddGlobal(
                 llvm.module,
-                self.ty.codegen_type(llvm, module),
+                self.ty.llvm_type(llvm, module),
                 cname.as_ptr(),
             );
 
             match self.expr {
                 Expr::Literal(_) => {
-                    let val = self.expr.codegen_value(llvm, module);
+                    let val = self.expr.llvm_value(llvm, module);
                     LLVMSetInitializer(global_var, val);
                 }
                 _ => panic!("Expression is unsupported for use as a global variable"),

--- a/crates/metal-codegen-llvm/src/stmt/constant.rs
+++ b/crates/metal-codegen-llvm/src/stmt/constant.rs
@@ -20,11 +20,8 @@ impl CodeGenValue for Constant {
         let cname = CString::new(self.name).unwrap();
 
         unsafe {
-            let global_var = LLVMAddGlobal(
-                llvm.module,
-                self.ty.llvm_type(llvm, module),
-                cname.as_ptr(),
-            );
+            let global_var =
+                LLVMAddGlobal(llvm.module, self.ty.llvm_type(llvm, module), cname.as_ptr());
 
             match self.expr {
                 Expr::Literal(_) => {

--- a/crates/metal-codegen-llvm/src/stmt/function_definition.rs
+++ b/crates/metal-codegen-llvm/src/stmt/function_definition.rs
@@ -14,7 +14,7 @@ use super::{CodeGenType, CodeGenValue};
 use crate::get_linkage_from_vis;
 
 impl CodeGenValue for FunctionDefinition {
-    fn codegen_value(
+    fn llvm_value(
         &self,
         llvm: &mut crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
@@ -29,7 +29,7 @@ impl CodeGenValue for FunctionDefinition {
             let function = LLVMAddFunction(
                 llvm.module,
                 c_fun_name.as_ptr(),
-                self.signature.codegen_type(llvm, module),
+                self.signature.llvm_type(llvm, module),
             );
             LLVMSetLinkage(function, linkage);
 
@@ -39,7 +39,7 @@ impl CodeGenValue for FunctionDefinition {
             llvm.locals.clear();
 
             for stmt in &self.body {
-                stmt.codegen_value(llvm, module);
+                stmt.llvm_value(llvm, module);
             }
 
             function

--- a/crates/metal-codegen-llvm/src/ty.rs
+++ b/crates/metal-codegen-llvm/src/ty.rs
@@ -9,13 +9,13 @@ pub mod function_signature;
 pub mod struct_;
 
 impl CodeGenType for Type {
-    fn codegen_type(
+    fn llvm_type(
         &self,
         llvm: &crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
     ) -> llvm_sys::prelude::LLVMTypeRef {
         match self {
-            Self::Primitive(p) => p.codegen_type(llvm, module),
+            Self::Primitive(p) => p.llvm_type(llvm, module),
             Self::Composite(c) => unsafe {
                 match c.as_ref() {
                     metal_mir::types::Composite::Tuple(t) => {
@@ -28,12 +28,12 @@ impl CodeGenType for Type {
                         )
                     }
                     metal_mir::types::Composite::Array(a) => {
-                        LLVMArrayType2(a.item_type.codegen_type(llvm, module), a.size)
+                        LLVMArrayType2(a.item_type.llvm_type(llvm, module), a.size)
                     }
                 }
             },
-            Self::Function(f) => f.codegen_type(llvm, module),
-            Self::Struct(s) => s.codegen_type(llvm, module),
+            Self::Function(f) => f.llvm_type(llvm, module),
+            Self::Struct(s) => s.llvm_type(llvm, module),
         }
     }
 }

--- a/crates/metal-codegen-llvm/src/ty/function_signature.rs
+++ b/crates/metal-codegen-llvm/src/ty/function_signature.rs
@@ -6,7 +6,7 @@ use metal_mir::types::function::FunctionSignature;
 use super::{get_types, CodeGenType};
 
 impl CodeGenType for FunctionSignature {
-    fn codegen_type(
+    fn llvm_type(
         &self,
         llvm: &crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
@@ -16,7 +16,7 @@ impl CodeGenType for FunctionSignature {
 
             let mut types_to_convert = get_types(llvm, module, &len, &self.inputs);
             LLVMFunctionType(
-                self.return_type.codegen_type(llvm, module),
+                self.return_type.llvm_type(llvm, module),
                 types_to_convert.as_mut_ptr(),
                 len.try_into().unwrap(),
                 0,

--- a/crates/metal-codegen-llvm/src/ty/struct_.rs
+++ b/crates/metal-codegen-llvm/src/ty/struct_.rs
@@ -24,7 +24,7 @@ fn get_types_struct(
 }
 
 impl CodeGenType for Struct {
-    fn codegen_type(
+    fn llvm_type(
         &self,
         llvm: &crate::LLVMRefs,
         module: &metal_mir::parcel::Module,


### PR DESCRIPTION
Rename LLVM Codegen trait function names to avoid conflicts with future WASM Codegen refactors.