### PR TITLE
feat(llvm): add function for compiling modules

### DIFF
--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+//! Compilation step for modules from MIR to LLVM IR
+
+use std::ffi::CString;
+
+use llvm_sys::{bit_writer, core::LLVMPrintModuleToString};
+use metal_mir::parcel::Module;
+
+use crate::{safeties::MemoryBuffer, CodeGenValue, LLVMRefs};
+
+/// Compiles an LLVM module and returns either human-readable
+/// LLVM IR or LLVM bytecode depending on `human_readable`.
+#[inline]
+pub fn compile_module(module: &Module, human_readable: bool) -> Vec<u8> {
+    let mut llvm = LLVMRefs::new(module);
+
+    for stmt in &module.statements {
+        stmt.llvm_value(&mut llvm, module);
+    }
+
+    if human_readable {
+        let module_ir = unsafe { CString::from_raw(LLVMPrintModuleToString(llvm.module)) };
+        module_ir.into_bytes()
+    } else {
+        let buf = unsafe { bit_writer::LLVMWriteBitcodeToMemoryBuffer(llvm.module) };
+        MemoryBuffer::new(buf).to_vec()
+    }
+}

--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -10,7 +10,6 @@ use crate::{safeties::MemoryBuffer, CodeGenValue, LLVMRefs};
 
 /// Compiles an LLVM module and returns either human-readable
 /// LLVM IR or LLVM bytecode depending on `human_readable`.
-#[inline]
 pub fn compile_module(module: &Module, human_readable: bool) -> Vec<u8> {
     let mut llvm = LLVMRefs::new(module);
 

--- a/crates/metal-codegen-llvm/src/safeties.rs
+++ b/crates/metal-codegen-llvm/src/safeties.rs
@@ -19,7 +19,6 @@ impl MemoryBuffer {
     }
 
     /// Turns an LLVM buffer into a Vec<u8>
-    #[inline]
     pub fn to_vec(&self) -> Vec<u8> {
         unsafe {
             let start = LLVMGetBufferStart(self.llvm_buf) as *const u8;

--- a/crates/metal-codegen-llvm/src/safeties.rs
+++ b/crates/metal-codegen-llvm/src/safeties.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+//! Safe Rust abstractions for several LLVM types
+
+use std::slice;
+
+use llvm_sys::{
+    core::{LLVMDisposeMemoryBuffer, LLVMGetBufferSize, LLVMGetBufferStart},
+    prelude::LLVMMemoryBufferRef,
+};
+
+/// Safe abstraction over LLVM's MemoryBuffer
+pub struct MemoryBuffer {
+    llvm_buf: LLVMMemoryBufferRef,
+}
+
+impl MemoryBuffer {
+    pub fn new(buf: LLVMMemoryBufferRef) -> Self {
+        Self { llvm_buf: buf }
+    }
+
+    /// Turns an LLVM buffer into a Vec<u8>
+    #[inline]
+    pub fn to_vec(&self) -> Vec<u8> {
+        unsafe {
+            let start = LLVMGetBufferStart(self.llvm_buf) as *const u8;
+            let size = LLVMGetBufferSize(self.llvm_buf) as usize;
+            slice::from_raw_parts(start, size).to_vec()
+        }
+    }
+}
+
+impl Drop for MemoryBuffer {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeMemoryBuffer(self.llvm_buf) };
+    }
+}


### PR DESCRIPTION
Adds the function `compile_module` which compiles an individual module.

Also:

- Adds `Drop` impl for LLVMRefs
- Adds `MemoryBuffer` safe abstraction over LLVM's MemoryBuffer (may be moved to another module)