### PR TITLE
tests(llvm): core module tests

### DIFF
--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //! Compilation step for modules from MIR to LLVM IR
 
-use std::ffi::CString;
+use std::{borrow::Cow, ffi::CString};
 
 use llvm_sys::{analysis::LLVMVerifyModule, bit_writer, core::LLVMPrintModuleToString};
 use metal_mir::parcel::Module;
@@ -10,6 +10,48 @@ use crate::{
     safeties::{LLVMErrorMessage, MemoryBuffer},
     CodeGenValue, LLVMRefs,
 };
+
+// TODO: move to AST once ast-ng is complete.
+pub struct PathBuilder<'a> {
+    inner: Vec<Cow<'a, str>>,
+}
+
+impl Default for PathBuilder<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> PathBuilder<'a> {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    pub fn push(&mut self, content: &'a str) {
+        self.inner.push(Cow::from(content));
+    }
+
+    pub fn finish(&mut self) -> String {
+        self.inner.reverse();
+        self.inner.join(".")
+    }
+}
+
+pub fn get_module_full_name(module: &Module) -> String {
+    let mut builder = PathBuilder::new();
+    let mut last_module = &Some(Box::new(module));
+
+    loop {
+        if let Some(module) = last_module {
+            builder.push(module.name.as_str());
+            last_module = &module.parent;
+            continue;
+        }
+        break;
+    }
+
+    builder.finish()
+}
 
 /// Compiles an LLVM module and returns either human-readable
 /// LLVM IR or LLVM bytecode depending on `human_readable`.
@@ -55,10 +97,10 @@ mod tests {
 
     use super::*;
 
-    fn get_empty_module() -> Module {
+    fn get_empty_module<'a>(name: String, parent: Option<&'a Module<'a>>) -> Module<'a> {
         Module {
-            name: "testmodule".to_string(),
-            parent: Option::None,
+            name,
+            parent: parent.map(Box::new),
             children: Vec::new(),
             statements: Vec::new(),
             function_signatures: Vec::new(),
@@ -70,7 +112,7 @@ mod tests {
 
     #[test]
     fn test_empty_module() {
-        let module = get_empty_module();
+        let module = get_empty_module("empty".to_string(), None);
         let compiled = String::from_utf8(compile_module(&module, true)).unwrap();
         assert_ne!(compiled, "".to_string());
         println!("compiled module: \n\n{}", compiled);
@@ -78,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_module_function() {
-        let mut module = get_empty_module();
+        let mut module = get_empty_module("testing".to_string(), None);
 
         // add function to module
         let sig = FunctionSignature {
@@ -112,11 +154,10 @@ mod tests {
             ]
             .to_vec(),
         };
+        let stmt = Statement::FunctionDefine(Box::new(def));
 
-        module.function_signatures.push(sig);
-        module
-            .statements
-            .push(Statement::FunctionDefine(Box::new(def)));
+        module.function_signatures.push(&sig);
+        module.statements.push(&stmt);
 
         let compiled = String::from_utf8(compile_module(&module, true)).unwrap();
         assert_ne!(compiled, "".to_string());
@@ -126,7 +167,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_panic_global_var_expr() {
-        let mut module = get_empty_module();
+        let mut module = get_empty_module("testing".to_string(), None);
         let global_var = Constant {
             name: "some_constant",
             expr: Expr::Div(Box::new(MathematicalValue {
@@ -145,11 +186,59 @@ mod tests {
             ty: Primitive::I32,
             vis: metal_mir::types::visibility::Visibility::Private,
         };
+        let stmt = Statement::Constant(Box::new(global_var));
 
-        module
-            .statements
-            .push(Statement::Constant(Box::new(global_var)));
+        module.statements.push(&stmt);
 
         compile_module(&module, true);
+    }
+
+    #[test]
+    fn test_nested_module_function() {
+        // NOTE `children` is not appended to cause Rust sucks.
+        let module = get_empty_module("core".to_string(), None);
+        let another_module = get_empty_module("lib".to_string(), Some(&module));
+        let mut last_module = get_empty_module("str".to_string(), Some(&another_module));
+
+        // add function to module
+        let sig = FunctionSignature {
+            name: "turn_into".to_string(),
+            return_type: Type::Primitive(Box::new(Primitive::Void)),
+            inputs: Vec::new(),
+            vis: metal_mir::types::visibility::Visibility::Public,
+        };
+        let def = FunctionDefinition {
+            module: last_module.clone(),
+            signature: sig.clone(),
+            body: [
+                Statement::Let(Box::new(Assignment {
+                    name: "a_variable",
+                    ty: Type::Primitive(Box::new(Primitive::U8)),
+                    expr: Some(Expr::Add(Box::new(MathematicalValue {
+                        a: Expr::Literal(Box::new(Literal::Number(Number {
+                            primitive: Primitive::U8,
+                            value: 5,
+                        }))),
+                        b: Expr::Literal(Box::new(Literal::Number(Number {
+                            primitive: Primitive::U8,
+                            value: 8,
+                        }))),
+                        signed: false,
+                        float: false,
+                        result_var_name: Some("a_variable"),
+                    }))),
+                })),
+                Statement::Return(None),
+            ]
+            .to_vec(),
+        };
+        let stmt = Statement::FunctionDefine(Box::new(def));
+
+        last_module.function_signatures.push(&sig);
+        last_module.statements.push(&stmt);
+
+        let compiled = String::from_utf8(compile_module(&last_module, true)).unwrap();
+        assert_ne!(compiled, "".to_string());
+        println!("compiled module: \n\n{}", compiled);
     }
 }

--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -25,3 +25,118 @@ pub fn compile_module(module: &Module, human_readable: bool) -> Vec<u8> {
         MemoryBuffer::new(buf).to_vec()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use metal_mir::{
+        expr::{
+            literals::{Literal, Number},
+            Assignment, Expr, Load, MathematicalValue,
+        },
+        stmt::{constant::Constant, functiondef::FunctionDefinition, return_::Return, Statement},
+        types::{function::FunctionSignature, primitives::Primitive, Type},
+    };
+
+    use super::*;
+
+    fn get_empty_module() -> Module {
+        Module {
+            name: "testmodule".to_string(),
+            parent: Option::None,
+            children: Vec::new(),
+            statements: Vec::new(),
+            function_signatures: Vec::new(),
+            imports: Vec::new(),
+            constants: Vec::new(),
+            structs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_empty_module() {
+        let module = get_empty_module();
+        let compiled = String::from_utf8(compile_module(&module, true)).unwrap();
+        assert_ne!(compiled, "".to_string());
+        println!("compiled module: \n\n{}", compiled);
+    }
+
+    #[test]
+    fn test_module_function() {
+        let mut module = get_empty_module();
+
+        // add function to module
+        let sig = FunctionSignature {
+            name: "main".to_string(),
+            return_type: Type::Primitive(Box::new(Primitive::Void)),
+            inputs: Vec::new(),
+            vis: metal_mir::types::visibility::Visibility::Public,
+        };
+        let def = FunctionDefinition {
+            module: module.clone(),
+            signature: sig.clone(),
+            body: [
+                Statement::Let(Box::new(Assignment {
+                    name: "a_variable",
+                    ty: Type::Primitive(Box::new(Primitive::U8)),
+                    expr: Some(Expr::Add(Box::new(MathematicalValue {
+                        a: Expr::Literal(Box::new(Literal::Number(Number {
+                            primitive: Primitive::U8,
+                            value: 5,
+                        }))),
+                        b: Expr::Literal(Box::new(Literal::Number(Number {
+                            primitive: Primitive::U8,
+                            value: 8,
+                        }))),
+                        signed: false,
+                        float: false,
+                        result_var_name: Some("a_variable"),
+                    }))),
+                })),
+                Statement::Return(Box::new(Return(Expr::Load(Box::new(Load {
+                    name: "a_variable",
+                    ty: Type::Primitive(Box::new(Primitive::U8)),
+                }))))),
+            ]
+            .to_vec(),
+        };
+
+        module.function_signatures.push(sig);
+        module
+            .statements
+            .push(Statement::FunctionDefine(Box::new(def)));
+
+        let compiled = String::from_utf8(compile_module(&module, true)).unwrap();
+        assert_ne!(compiled, "".to_string());
+        println!("compiled module: \n\n{}", compiled);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_panic_global_var_expr() {
+        let mut module = get_empty_module();
+        let global_var = Constant {
+            name: "some_constant",
+            expr: Expr::Div(Box::new(MathematicalValue {
+                a: Expr::Literal(Box::new(Literal::Number(Number {
+                    primitive: Primitive::I32,
+                    value: 40,
+                }))),
+                b: Expr::Literal(Box::new(Literal::Number(Number {
+                    primitive: Primitive::I32,
+                    value: 40,
+                }))),
+                signed: true,
+                float: false,
+                result_var_name: Some("some_constant"),
+            })),
+            ty: Primitive::I32,
+            vis: metal_mir::types::visibility::Visibility::Private,
+        };
+
+        module
+            .statements
+            .push(Statement::Constant(Box::new(global_var)));
+
+        compile_module(&module, true);
+    }
+}

--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -96,7 +96,7 @@ mod tests {
     fn get_empty_module<'a>(name: String, parent: Option<&'a Module<'a>>) -> Module<'a> {
         Module {
             name,
-            parent: parent.map(Box::new),
+            parent,
             children: Vec::new(),
             statements: Vec::new(),
             function_signatures: Vec::new(),

--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -39,7 +39,7 @@ impl<'a> PathBuilder<'a> {
 
 pub fn get_module_full_name(module: &Module) -> String {
     let mut builder = PathBuilder::new();
-    let mut last_module = &Some(Box::new(module));
+    let mut last_module = &Some(module);
 
     while let Some(module) = last_module {
         builder.push(module.name.as_str());

--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -115,7 +115,6 @@ mod tests {
         let module = get_empty_module("empty".to_string(), None);
         let compiled = String::from_utf8(compile_module(&module, true)).unwrap();
         assert_ne!(compiled, "".to_string());
-        println!("compiled module: \n\n{}", compiled);
     }
 
     #[test]
@@ -161,7 +160,6 @@ mod tests {
 
         let compiled = String::from_utf8(compile_module(&module, true)).unwrap();
         assert_ne!(compiled, "".to_string());
-        println!("compiled module: \n\n{}", compiled);
     }
 
     #[test]
@@ -239,6 +237,5 @@ mod tests {
 
         let compiled = String::from_utf8(compile_module(&last_module, true)).unwrap();
         assert_ne!(compiled, "".to_string());
-        println!("compiled module: \n\n{}", compiled);
     }
 }

--- a/crates/metal-codegen-llvm/src/core.rs
+++ b/crates/metal-codegen-llvm/src/core.rs
@@ -41,13 +41,9 @@ pub fn get_module_full_name(module: &Module) -> String {
     let mut builder = PathBuilder::new();
     let mut last_module = &Some(Box::new(module));
 
-    loop {
-        if let Some(module) = last_module {
-            builder.push(module.name.as_str());
-            last_module = &module.parent;
-            continue;
-        }
-        break;
+    while let Some(module) = last_module {
+        builder.push(module.name.as_str());
+        last_module = &module.parent;
     }
 
     builder.finish()

--- a/crates/metal-codegen-llvm/src/safeties.rs
+++ b/crates/metal-codegen-llvm/src/safeties.rs
@@ -54,7 +54,8 @@ impl LLVMErrorMessage {
         }
     }
 
-    pub fn llvm(&self) -> *mut i8 {
+    /// Returns a representation which can be used in LLVM functions.
+    pub fn llvm(&self) -> *mut c_char {
         self.ptr
     }
 

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -37,7 +37,7 @@ impl CodeGenValue for Statement<'_> {
             },
             Self::Return(expr) => unsafe {
                 if let Some(e) = expr {
-                    LLVMBuildRet(llvm.builder, (*e).0.llvm_value(llvm, module))
+                    LLVMBuildRet(llvm.builder, e.0.llvm_value(llvm, module))
                 } else {
                     LLVMBuildRetVoid(llvm.builder)
                 }

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -12,7 +12,7 @@ use super::{CodeGenType, CodeGenValue};
 pub mod constant;
 pub mod function_definition;
 
-impl CodeGenValue for Statement {
+impl CodeGenValue for Statement<'_> {
     fn llvm_value(
         &self,
         llvm: &mut crate::LLVMRefs,

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -36,7 +36,7 @@ impl CodeGenValue for Statement<'_> {
                 LLVMAddFunction(llvm.module, c_name.as_ptr(), e.llvm_type(llvm, module))
             },
             Self::Return(expr) => unsafe {
-                if let Some(e) = expr.to_owned() {
+                if let Some(e) = expr {
                     LLVMBuildRet(llvm.builder, (*e).0.llvm_value(llvm, module))
                 } else {
                     LLVMBuildRetVoid(llvm.builder)

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -3,7 +3,7 @@
 use std::ffi::CString;
 
 use llvm_sys::{
-    core::{LLVMAddFunction, LLVMBuildAlloca, LLVMBuildStore},
+    core::{LLVMAddFunction, LLVMBuildAlloca, LLVMBuildRet, LLVMBuildStore},
     prelude::LLVMValueRef,
 };
 use metal_mir::stmt::Statement;
@@ -34,6 +34,10 @@ impl CodeGenValue for Statement {
             Self::Extern(e) => unsafe {
                 let c_name = CString::new(e.name.as_str()).unwrap();
                 LLVMAddFunction(llvm.module, c_name.as_ptr(), e.llvm_type(llvm, module))
+            },
+            Self::Return(expr) => unsafe {
+                let e = expr.to_owned();
+                LLVMBuildRet(llvm.builder, (*e).0.llvm_value(llvm, module))
             },
         }
     }

--- a/crates/metal-codegen-llvm/src/stmt.rs
+++ b/crates/metal-codegen-llvm/src/stmt.rs
@@ -3,7 +3,7 @@
 use std::ffi::CString;
 
 use llvm_sys::{
-    core::{LLVMAddFunction, LLVMBuildAlloca, LLVMBuildRet, LLVMBuildStore},
+    core::{LLVMAddFunction, LLVMBuildAlloca, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore},
     prelude::LLVMValueRef,
 };
 use metal_mir::stmt::Statement;
@@ -36,8 +36,11 @@ impl CodeGenValue for Statement {
                 LLVMAddFunction(llvm.module, c_name.as_ptr(), e.llvm_type(llvm, module))
             },
             Self::Return(expr) => unsafe {
-                let e = expr.to_owned();
-                LLVMBuildRet(llvm.builder, (*e).0.llvm_value(llvm, module))
+                if let Some(e) = expr.to_owned() {
+                    LLVMBuildRet(llvm.builder, (*e).0.llvm_value(llvm, module))
+                } else {
+                    LLVMBuildRetVoid(llvm.builder)
+                }
             },
         }
     }

--- a/crates/metal-codegen-llvm/src/stmt/function_definition.rs
+++ b/crates/metal-codegen-llvm/src/stmt/function_definition.rs
@@ -11,15 +11,20 @@ use llvm_sys::{
 use metal_mir::stmt::functiondef::FunctionDefinition;
 
 use super::{CodeGenType, CodeGenValue};
-use crate::get_linkage_from_vis;
+use crate::{core::get_module_full_name, get_linkage_from_vis};
 
-impl CodeGenValue for FunctionDefinition {
+impl CodeGenValue for FunctionDefinition<'_> {
     fn llvm_value(
         &self,
         llvm: &mut crate::LLVMRefs,
         module: &metal_mir::parcel::Module,
     ) -> LLVMValueRef {
-        let fun_name = self.signature.name.as_str();
+        let fun_name = if self.signature.name != "main" {
+            let module_name = get_module_full_name(module);
+            String::new() + module_name.as_str() + "." + self.signature.name.as_str()
+        } else {
+            self.signature.name.clone()
+        };
 
         let linkage = get_linkage_from_vis(&self.signature.vis);
 

--- a/crates/metal-codegen-llvm/src/stmt/function_definition.rs
+++ b/crates/metal-codegen-llvm/src/stmt/function_definition.rs
@@ -21,7 +21,7 @@ impl CodeGenValue for FunctionDefinition<'_> {
     ) -> LLVMValueRef {
         let fun_name = if self.signature.name != "main" {
             let module_name = get_module_full_name(module);
-            String::new() + module_name.as_str() + "." + self.signature.name.as_str()
+            module_name + "." + self.signature.name.as_str()
         } else {
             self.signature.name.clone()
         };

--- a/crates/metal-mir/src/parcel.rs
+++ b/crates/metal-mir/src/parcel.rs
@@ -21,7 +21,7 @@ pub struct Module<'a> {
     pub name: String,
     /// If this is a submodule
     /// includes the higher-level parent.
-    pub parent: Option<Box<&'a Module<'a>>>,
+    pub parent: Option<&'a Module<'a>>,
     /// Submodules inside of this module.
     /// Should be empty if module isn't a folder.
     pub children: Vec<&'a Module<'a>>,

--- a/crates/metal-mir/src/parcel.rs
+++ b/crates/metal-mir/src/parcel.rs
@@ -24,7 +24,7 @@ pub struct Module<'a> {
     pub parent: Option<Box<&'a Module<'a>>>,
     /// Submodules inside of this module.
     /// Should be empty if module isn't a folder.
-    pub children: Vec<Box<&'a Module<'a>>>,
+    pub children: Vec<&'a Module<'a>>,
     /// An exhaustive list of the statements
     /// the module includes.
     pub statements: Vec<&'a stmt::Statement<'a>>,

--- a/crates/metal-mir/src/parcel.rs
+++ b/crates/metal-mir/src/parcel.rs
@@ -5,37 +5,37 @@
 use crate::{stmt, types};
 
 #[derive(Debug, Clone)]
-pub struct Parcel {
+pub struct Parcel<'a> {
     /// Parcel name.
     /// i.e. `std`
     pub name: String,
     /// Modules included in
     /// this parcel.
-    pub modules: Vec<Module>,
+    pub modules: Vec<Module<'a>>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Module {
+pub struct Module<'a> {
     /// Module name.
     /// i.e. `io`
     pub name: String,
     /// If this is a submodule
     /// includes the higher-level parent.
-    pub parent: Option<Box<Module>>,
+    pub parent: Option<Box<&'a Module<'a>>>,
     /// Submodules inside of this module.
     /// Should be empty if module isn't a folder.
-    pub children: Vec<Box<Module>>,
+    pub children: Vec<Box<&'a Module<'a>>>,
     /// An exhaustive list of the statements
     /// the module includes.
-    pub statements: Vec<stmt::Statement>,
+    pub statements: Vec<&'a stmt::Statement<'a>>,
     /// Signatures of all functions in this module.
     /// Used for function calls to avoid relying on
     /// where a function is located in a module.
-    pub function_signatures: Vec<types::function::FunctionSignature>,
+    pub function_signatures: Vec<&'a types::function::FunctionSignature>,
     /// All imports declared within this module.
-    pub imports: Vec<stmt::import::Import>,
+    pub imports: Vec<&'a stmt::import::Import<'a>>,
     /// All of the defined constants in this module.
-    pub constants: Vec<stmt::constant::Constant>,
+    pub constants: Vec<&'a stmt::constant::Constant>,
     /// All of the defined structs in this module.
-    pub structs: Vec<super::struct_::Struct>,
+    pub structs: Vec<&'a super::struct_::Struct>,
 }

--- a/crates/metal-mir/src/stmt/functiondef.rs
+++ b/crates/metal-mir/src/stmt/functiondef.rs
@@ -5,11 +5,11 @@ use crate::{parcel, types};
 
 /// Represents a definition for a function.
 #[derive(Debug, Clone)]
-pub struct FunctionDefinition {
+pub struct FunctionDefinition<'a> {
     /// The module of this function.
-    pub module: parcel::Module,
+    pub module: parcel::Module<'a>,
     /// The function signature/identifier/type.
     pub signature: types::function::FunctionSignature,
     /// The body of this function.
-    pub body: Vec<Statement>,
+    pub body: Vec<Statement<'a>>,
 }

--- a/crates/metal-mir/src/stmt/import.rs
+++ b/crates/metal-mir/src/stmt/import.rs
@@ -24,9 +24,9 @@ use crate::{parcel::Module, struct_, types};
 /// }
 /// ```
 #[derive(Debug, Clone)]
-pub struct Import {
+pub struct Import<'a> {
     /// The module imported.
-    pub module: Box<Module>,
+    pub module: Box<Module<'a>>,
     /// The functions imported.
     pub functions: Vec<types::function::FunctionSignature>,
     /// The structs imported.
@@ -34,5 +34,5 @@ pub struct Import {
     /// The constants imported.
     pub constants: Vec<super::constant::Constant>,
     /// The next level of imports.
-    pub children: Vec<Import>,
+    pub children: Vec<Import<'a>>,
 }

--- a/crates/metal-mir/src/stmt/mod.rs
+++ b/crates/metal-mir/src/stmt/mod.rs
@@ -9,8 +9,8 @@ pub mod return_;
 
 /// Represents a statement in Metal code.
 #[derive(Debug, Clone)]
-pub enum Statement {
-    FunctionDefine(Box<functiondef::FunctionDefinition>),
+pub enum Statement<'a> {
+    FunctionDefine(Box<functiondef::FunctionDefinition<'a>>),
     Constant(Box<constant::Constant>),
     Let(Box<Assignment>),
     Extern(Box<FunctionSignature>),

--- a/crates/metal-mir/src/stmt/mod.rs
+++ b/crates/metal-mir/src/stmt/mod.rs
@@ -14,5 +14,5 @@ pub enum Statement {
     Constant(Box<constant::Constant>),
     Let(Box<Assignment>),
     Extern(Box<FunctionSignature>),
-    Return(Box<return_::Return>),
+    Return(Option<Box<return_::Return>>),
 }

--- a/crates/metal-mir/src/stmt/mod.rs
+++ b/crates/metal-mir/src/stmt/mod.rs
@@ -5,6 +5,7 @@ use crate::{expr::Assignment, types::function::FunctionSignature};
 pub mod constant;
 pub mod functiondef;
 pub mod import;
+pub mod return_;
 
 /// Represents a statement in Metal code.
 #[derive(Debug, Clone)]
@@ -13,4 +14,5 @@ pub enum Statement {
     Constant(Box<constant::Constant>),
     Let(Box<Assignment>),
     Extern(Box<FunctionSignature>),
+    Return(Box<return_::Return>),
 }

--- a/crates/metal-mir/src/stmt/return_.rs
+++ b/crates/metal-mir/src/stmt/return_.rs
@@ -1,5 +1,5 @@
 use crate::expr::Expr;
 
-/// Rerpresents a return statement. i.e. `return 15`
+/// Represents a return statement. i.e. `return 15`
 #[derive(Debug, Clone)]
 pub struct Return(pub Expr);

--- a/crates/metal-mir/src/stmt/return_.rs
+++ b/crates/metal-mir/src/stmt/return_.rs
@@ -1,0 +1,5 @@
+use crate::expr::Expr;
+
+/// Rerpresents a return statement. i.e. `return 15`
+#[derive(Debug, Clone)]
+pub struct Return(pub Expr);


### PR DESCRIPTION
Adds some basic tests for `metal_codegen_llvm`.

Also adds the `Return` statement and module verification in `compile_module` because I'm too lazy to make a separate PR. (and so what's compiled is a valid LLVM program)