### PR TITLE
feat: add unknown as an intermediate MIR type

### DIFF
--- a/crates/metal-codegen-llvm/src/ty.rs
+++ b/crates/metal-codegen-llvm/src/ty.rs
@@ -34,7 +34,7 @@ impl CodeGenType for Type {
             },
             Self::Function(f) => f.llvm_type(llvm, module),
             Self::Struct(s) => s.llvm_type(llvm, module),
-            Self::Unknown => panic!("Unknown types cannot be compiled")
+            Self::Unknown => panic!("Unknown types cannot be compiled"),
         }
     }
 }

--- a/crates/metal-codegen-llvm/src/ty.rs
+++ b/crates/metal-codegen-llvm/src/ty.rs
@@ -34,7 +34,7 @@ impl CodeGenType for Type {
             },
             Self::Function(f) => f.llvm_type(llvm, module),
             Self::Struct(s) => s.llvm_type(llvm, module),
-            Self::Unknown => panic!("Unknown types cannot be compiled"),
+            Self::Unknown => unreachable!(),
         }
     }
 }

--- a/crates/metal-codegen-llvm/src/ty.rs
+++ b/crates/metal-codegen-llvm/src/ty.rs
@@ -34,6 +34,7 @@ impl CodeGenType for Type {
             },
             Self::Function(f) => f.llvm_type(llvm, module),
             Self::Struct(s) => s.llvm_type(llvm, module),
+            Self::Unknown => panic!("Unknown types cannot be compiled")
         }
     }
 }

--- a/crates/metal-mir/src/types/mod.rs
+++ b/crates/metal-mir/src/types/mod.rs
@@ -21,7 +21,7 @@ pub enum Type {
     /// This should not be provided to codegen,
     /// and is only intended as an intermediate type
     /// representation while attempting to build types
-    Unknown
+    Unknown,
 }
 
 /// Represents an array type or a group of types.

--- a/crates/metal-mir/src/types/mod.rs
+++ b/crates/metal-mir/src/types/mod.rs
@@ -17,6 +17,11 @@ pub enum Type {
     Primitive(Box<primitives::Primitive>),
     Function(Box<function::FunctionSignature>),
     Struct(Box<struct_::Struct>),
+    /// Specifies the type can't be known or isn't known yet.
+    /// This should not be provided to codegen,
+    /// and is only intended as an intermediate type
+    /// representation while attempting to build types
+    Unknown
 }
 
 /// Represents an array type or a group of types.


### PR DESCRIPTION
Add an unknown intermediate MIR type to make building types easier in the analyzer.