### PR TITLE
refactor: Asbtract away parser mode tracking

### DIFF
--- a/crates/metal-parser-ng/src/type_.rs
+++ b/crates/metal-parser-ng/src/type_.rs
@@ -15,26 +15,25 @@ pub fn parse_type(parser: &mut crate::parser::parser_type!()) {
     let at = parser.checkpoint();
 
     parser.start_node(N![Type]);
-    let old_mode = parser.enter_mode(ParserMode::Type);
 
-    match parser.peek().expect("expected a type").kind {
-        T![@ident] => parse_name_type(parser),
-        T![&] => parse_ref_type(parser),
-        other => todo!("{other:#?}"),
-    }
-
-    parser.end_node();
-
-    if parser.peek().is_some_and(|t| is_binary_type_op(t.kind)) {
-        parser.start_node_at(N![BinaryTypeOp], at);
-
-        parser.eat_any();
-        parse_type(parser);
+    parser.in_mode(ParserMode::Type, |parser| {
+        match parser.peek().expect("expected a type").kind {
+            T![@ident] => parse_name_type(parser),
+            T![&] => parse_ref_type(parser),
+            other => todo!("{other:#?}"),
+        }
 
         parser.end_node();
-    }
 
-    parser.enter_mode(old_mode);
+        if parser.peek().is_some_and(|t| is_binary_type_op(t.kind)) {
+            parser.start_node_at(N![BinaryTypeOp], at);
+
+            parser.eat_any();
+            parse_type(parser);
+
+            parser.end_node();
+        }
+    });
 }
 
 fn is_binary_type_op(kind: SyntaxKind) -> bool {


### PR DESCRIPTION
Also fixes a bug where a token would not be split if it was computed before the mode change, such as in `type A = &&B`